### PR TITLE
fix: handle boosters leaving guilds

### DIFF
--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -27,6 +27,7 @@ export default class RoBoostClient<Ready extends boolean = boolean> extends Clie
   }
 
   private async ready (): Promise<void> {
+    this.bindEvent('guildMemberRemove')
     this.bindEvent('guildMemberUpdate')
 
     console.log(`Ready to serve on ${this.guilds.cache.size} servers, for ${this.users.cache.size} users.`)

--- a/src/client/events/guild-member-remove.ts
+++ b/src/client/events/guild-member-remove.ts
@@ -1,0 +1,24 @@
+import { inject, injectable, named } from 'inversify'
+import type { BaseHandler } from '..'
+import { BaseJob } from '../../jobs'
+import type { GuildMember } from 'discord.js'
+import { constants } from '../../utils'
+
+const { TYPES } = constants
+
+@injectable()
+export default class GuildMemberUpdateEventHandler implements BaseHandler {
+  @inject(TYPES.Job)
+  @named('updatePlaytesters')
+  private readonly updatePlaytestersJob!: BaseJob
+
+  public async handle (member: GuildMember): Promise<void> {
+    if (member.premiumSince !== null) {
+      await this.updatePlaytestersJob.run(
+        parseInt(process.env.UNIVERSE_ID as string),
+        process.env.GUILD_ID,
+        process.env.OUTPUT_CHANNEL_ID
+      )
+    }
+  }
+}

--- a/src/client/events/index.ts
+++ b/src/client/events/index.ts
@@ -1,1 +1,2 @@
+export { default as GuildMemberRemoveEventHandler } from './guild-member-remove'
 export { default as GuildMemberUpdateEventHandler } from './guild-member-update'

--- a/src/configs/container.ts
+++ b/src/configs/container.ts
@@ -18,6 +18,8 @@ bind<BloxyClient>(TYPES.BloxyClient).toDynamicValue(() => new BloxyClient({ rest
   .inSingletonScope()
 
 // Event Handlers
+bind<BaseHandler>(TYPES.Handler).to(eventHandlers.GuildMemberRemoveEventHandler)
+  .whenTargetTagged('eventHandler', 'guildMemberRemove')
 bind<BaseHandler>(TYPES.Handler).to(eventHandlers.GuildMemberUpdateEventHandler)
   .whenTargetTagged('eventHandler', 'guildMemberUpdate')
 


### PR DESCRIPTION
If a booster leaves a guild, the UpdatePlaytestersJob wasn't run and thus they would keep being a playtester until the next time the job runs, this PR fixes that.